### PR TITLE
WIP DDF-SUPPORT-4: created bundle auto versioning plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 install: mvn install --quiet -DskipTests=true -B
 language: java
 jdk:
-  - oraclejdk8
+  - openjdk8
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,130 @@
+@Library('github.com/connexta/cx-pipeline-library@master') _
+@Library('github.com/connexta/github-utils-shared-library@master') __
+
+pipeline {
+    agent {
+        node {
+            label 'linux-small'
+            customWorkspace "/jenkins/workspace/${JOB_NAME}/${BUILD_NUMBER}"
+        }
+    }
+    options {
+        buildDiscarder(logRotator(numToKeepStr:'25'))
+        disableConcurrentBuilds()
+        timestamps()
+        skipDefaultCheckout()
+    }
+    triggers {
+        /*
+          Restrict nightly builds to master branch, all others will be built on change only.
+          Note: The BRANCH_NAME will only work with a multi-branch job using the github-branch-source
+        */
+        cron(BRANCH_NAME == "master" ? "@weekly" : "")
+		pollSCM("H/10 * * * *")
+    }
+    environment {
+        LARGE_MVN_OPTS = '-Xmx8192M -Xss128M -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC '
+        LINUX_MVN_RANDOM = '-Djava.security.egd=file:/dev/./urandom'
+        GITHUB_USERNAME = 'codice'
+        GITHUB_TOKEN = credentials('github-api-cred')
+        GITHUB_REPONAME = 'ddf-support'
+    }
+    stages {
+        stage('Setup') {
+            steps {
+                dockerd {}
+                slackSend color: 'good', message: "STARTED: ${JOB_NAME} ${BUILD_NUMBER} ${BUILD_URL}"
+                postCommentIfPR("Internal build has been started, your results will be available at build completion.", "${GITHUB_USERNAME}", "${GITHUB_REPONAME}", "${GITHUB_TOKEN}")
+            }
+        }
+
+        // Checkout the repository
+        stage('Checkout repo') {
+            steps {
+                retry(3) {
+                    checkout([$class: 'GitSCM', branches: [[name: "refs/heads/${BRANCH_NAME}"]], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'WipeWorkspace'], [$class: 'LocalBranch', localBranch: "${BRANCH_NAME}"], [$class: 'CloneOption', timeout: 30, shallow: true]], submoduleCfg: [], userRemoteConfigs: scm.userRemoteConfigs ])
+                }
+            }
+        }
+
+        stage('Full Build') {
+            when {
+                expression { env.CHANGE_ID == null } 
+            }
+
+            options {
+                timeout(time: 1, unit: 'HOURS')
+            }
+            steps {
+                withMaven(maven: 'maven-latest', mavenSettingsConfig: 'feca3f61-1da1-4887-a9ad-dd4a41fd4423', mavenOpts: '${LARGE_MVN_OPTS} ${LINUX_MVN_RANDOM}') {
+                    sh 'mvn clean install -B -DskipITs'
+                }
+            }
+        }
+
+        /*
+          Deploy stage will only be executed for deployable branches. 
+          It will also only deploy in the presence of an environment variable JENKINS_ENV = 'prod'. This can be passed in globally from the jenkins master node settings.
+        */
+        stage('Deploy') {
+            when {
+                allOf {
+                    expression { env.CHANGE_ID == null }
+                    expression { env.BRANCH_NAME ==~ /((?:\d*\.)?\d*\.x|master)/ }
+                    environment name: 'JENKINS_ENV', value: 'prod'
+                }
+            }
+            options {
+                timeout(time: 1, unit: 'HOURS')
+            }
+            steps{
+                withMaven(maven: 'maven-latest', jdk: 'jdk8-latest', globalMavenSettingsConfig: '51e52749-c47a-4e11-9c58-0adf485626f5', mavenSettingsConfig: 'codice-maven-settings', mavenOpts: '${LINUX_MVN_RANDOM}') {
+                    sh 'mvn deploy -nsu -DskipTests=true -Dpmd.skip=true -Dfindbugs.skip=true -Dcheckstyle.skip=true'
+                }
+            }
+        }
+
+        stage ('SonarCloud') {
+            when {
+                // Currently Sonar is not run for pull requests
+                expression { env.CHANGE_ID == null }
+            }
+            environment {
+                SONARQUBE_GITHUB_TOKEN = credentials('SonarQubeGithubToken')
+                SONAR_TOKEN = credentials('sonarqube-token')
+            }
+            options {
+                timeout(time: 1, unit: 'HOURS')
+            }
+            steps {
+                withMaven(maven: 'maven-latest', jdk: 'jdk8-latest', globalMavenSettingsConfig: '51e52749-c47a-4e11-9c58-0adf485626f5', mavenSettingsConfig: 'feca3f61-1da1-4887-a9ad-dd4a41fd4423', mavenOpts: '${LARGE_MVN_OPTS} ${LINUX_MVN_RANDOM}') {
+                            sh 'mvn clean -q -B -DskipTests=true -Dfindbugs.skip=true -Dcheckstyle.skip=true org.jacoco:jacoco-maven-plugin:prepare-agent package sonar:sonar -Dsonar.host.url=https://sonarcloud.io -Dsonar.login=$SONAR_TOKEN  -Dsonar.organization=codice -Dsonar.projectKey=ddf-support:master -Dsonar.organization=codice'
+                }
+            }
+        }
+    }
+    post {
+        always{
+            postCommentIfPR("Build ${currentBuild.currentResult} See the job results in [legacy Jenkins UI](${BUILD_URL}) or in [Blue Ocean UI](${BUILD_URL}display/redirect).", "${GITHUB_USERNAME}", "${GITHUB_REPONAME}", "${GITHUB_TOKEN}")
+        }
+        success {
+            slackSend color: 'good', message: "SUCCESS: ${JOB_NAME} ${BUILD_NUMBER}"
+        }
+        failure {
+            slackSend color: '#ea0017', message: "FAILURE: ${JOB_NAME} ${BUILD_NUMBER}. See the results here: ${BUILD_URL}"
+        }
+        unstable {
+            slackSend color: '#ffb600', message: "UNSTABLE: ${JOB_NAME} ${BUILD_NUMBER}. See the results here: ${BUILD_URL}"
+        }
+        cleanup {
+            catchError(buildResult: null, stageResult: 'FAILURE') {
+                echo '...Cleaning up workspace'
+                cleanWs()
+                sh 'rm -rf ~/.m2/repository'
+                wrap([$class: 'MesosSingleUseSlave']) {
+                    sh 'echo "...Shutting down Jenkins slave: `hostname`"'
+                }
+            }
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <!--
 /*
- * Copyright (c) Codice Foundation
+ * Copyright (c) Connexta, LLC
  *
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
  * version 3 of the License, or any later version. 
@@ -10,24 +10,20 @@
  * <http://www.gnu.org/licenses/lgpl.html>.
  */
 -->
-<img src="https://tools.codice.org/wiki/download/attachments/3047458/ddf.jpg"/>
-# [Distributed Data Framework Support \(DDF-Support\)](http://ddf.codice.org/)
-[![Build Status](https://travis-ci.org/codice/ddf-support.png?branch=master)](https://travis-ci.org/codice/ddf-support)
+[![Build Status](https://travis-ci.org/connexta/ddf-support.png?branch=master)](https://travis-ci.org/connexta/ddf-support)
 
 
 DDF-Support is an open source project integrated with the DDF integration framework. 
 
 ```
-git clone git://github.com/codice/ddf-support.git
+git clone git://github.com/connexta/ddf-support.git
 ```
 
 ## Additional information
-Please refer to the DDF readme on https://github.com/codice/ddf for more information.
-
--- The Codice DDF Development Team
+Please refer to the DDF readme on https://github.com/connexta/ddf for more information.
 
 ## Copyright / License
-Copyright (c) Codice Foundation
+Copyright (c) Connexta, LLC
  
 This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License 
 as published by the Free Software Foundation, either version 3 of the License, or any later version. 

--- a/gitsetup/pom.xml
+++ b/gitsetup/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>ddf.support</groupId>
         <artifactId>support-pom</artifactId>
-        <version>2.3.17-SNAPSHOT</version>
+        <version>2.3.17</version>
     </parent>
 
     <groupId>ddf.support</groupId>

--- a/gitsetup/pom.xml
+++ b/gitsetup/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>ddf.support</groupId>
         <artifactId>support-pom</artifactId>
-        <version>2.3.17</version>
+        <version>2.3.18-SNAPSHOT</version>
     </parent>
 
     <groupId>ddf.support</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     version if you want DDF apps to use latest support-checkstyle version; and update the <version> of the <parent> in child module
     support-checkstyle/pom.xml
     -->
-    <version>2.3.17-SNAPSHOT</version>
+    <version>2.3.17</version>
     <name>DDF Support</name>
     <description>DDF Support module contains support files for builds and site report generation
     </description>
@@ -65,7 +65,7 @@
         <url>https://github.com/codice/ddf-support.git</url>
         <connection>scm:git:git://github.com/codice/ddf-support.git</connection>
         <developerConnection>scm:git:git://github.com/codice/ddf-support.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>support-pom-2.3.17</tag>
     </scm>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     version if you want DDF apps to use latest support-checkstyle version; and update the <version> of the <parent> in child module
     support-checkstyle/pom.xml
     -->
-    <version>2.3.17</version>
+    <version>2.3.18-SNAPSHOT</version>
     <name>DDF Support</name>
     <description>DDF Support module contains support files for builds and site report generation
     </description>
@@ -65,7 +65,7 @@
         <url>https://github.com/codice/ddf-support.git</url>
         <connection>scm:git:git://github.com/codice/ddf-support.git</connection>
         <developerConnection>scm:git:git://github.com/codice/ddf-support.git</developerConnection>
-        <tag>support-pom-2.3.17</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -51,11 +51,11 @@
         <maven.clean.plugin.version>2.4.1</maven.clean.plugin.version>
         <maven.resources.plugin.version>2.5</maven.resources.plugin.version>
         <maven.javadoc.plugin.version>2.7</maven.javadoc.plugin.version>
-        <maven.release.plugin.version>2.5.1</maven.release.plugin.version>
+        <maven.release.plugin.version>3.0.0-M1</maven.release.plugin.version>
         <maven.site.plugin.version>3.4</maven.site.plugin.version>
         <maven.dependency.plugin.version>2.4</maven.dependency.plugin.version>
         <maven.compiler.plugin.version>2.3.2</maven.compiler.plugin.version>
-        <maven.deploy.plugin.version>2.6</maven.deploy.plugin.version>
+        <maven.deploy.plugin.version>3.0.0-M1</maven.deploy.plugin.version>
         <maven.install.plugin.version>2.3.1</maven.install.plugin.version>
         <maven.surefire.plugin.version>2.18.1</maven.surefire.plugin.version>
         <maven.jacoco.plugin.version>0.8.1</maven.jacoco.plugin.version>

--- a/support-checkstyle/pom.xml
+++ b/support-checkstyle/pom.xml
@@ -18,7 +18,7 @@
 	<parent>
 		<groupId>ddf.support</groupId>
 		<artifactId>support-pom</artifactId>
-		<version>2.3.17-SNAPSHOT</version>
+		<version>2.3.17</version>
 	</parent>
 
 	<artifactId>support-checkstyle</artifactId>

--- a/support-checkstyle/pom.xml
+++ b/support-checkstyle/pom.xml
@@ -18,7 +18,7 @@
 	<parent>
 		<groupId>ddf.support</groupId>
 		<artifactId>support-pom</artifactId>
-		<version>2.3.17</version>
+		<version>2.3.18-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>support-checkstyle</artifactId>

--- a/support-checkstyle/src/main/resources/lpgl-header-check-xml.txt
+++ b/support-checkstyle/src/main/resources/lpgl-header-check-xml.txt
@@ -2,7 +2,7 @@
 ^\s*<\?xml.*>\s*$
 ^\s*<!--\s*$
 ^\s*(<!--)?\s*/\*+\s*$
-^ \* Copyright \(c\) Codice Foundation\s*$
+^ \* Copyright \(c\) Connexta, LLC\s*$
 ^ \*\s*.*$
 ^ \* This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either\s*$
 ^ \* version 3 of the License, or any later version.\s*$

--- a/support-checkstyle/src/main/resources/lpgl-header-check.txt
+++ b/support-checkstyle/src/main/resources/lpgl-header-check.txt
@@ -2,7 +2,7 @@
 ^\s*<\?xml.*>\s*$
 ^\s*<!--\s*$
 ^\s*(<!--)?\s*/\*+\s*$
-^ \* Copyright \(c\) Codice Foundation\s*$
+^ \* Copyright \(c\) Connexta, LLC\s*$
 ^ \*\s*.*$
 ^ \* (<p>)?This is free software: you can redistribute it and/or modify it under the terms of the GNU(\sLesser)?\s*$
 ^ \* (Lesser\s)?General Public License as published by the Free Software Foundation, either version 3 of(\sthe)?\s*$

--- a/support-findbugs/pom.xml
+++ b/support-findbugs/pom.xml
@@ -18,7 +18,7 @@
     <parent>
             <groupId>ddf.support</groupId>
             <artifactId>support-pom</artifactId>
-            <version>2.3.17-SNAPSHOT</version>
+            <version>2.3.17</version>
     </parent>
 
     <artifactId>support-findbugs</artifactId>

--- a/support-findbugs/pom.xml
+++ b/support-findbugs/pom.xml
@@ -18,7 +18,7 @@
     <parent>
             <groupId>ddf.support</groupId>
             <artifactId>support-pom</artifactId>
-            <version>2.3.17</version>
+            <version>2.3.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>support-findbugs</artifactId>

--- a/support-githooks/pom.xml
+++ b/support-githooks/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>ddf.support</groupId>
         <artifactId>support-pom</artifactId>
-        <version>2.3.17-SNAPSHOT</version>
+        <version>2.3.17</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/support-githooks/pom.xml
+++ b/support-githooks/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>ddf.support</groupId>
         <artifactId>support-pom</artifactId>
-        <version>2.3.17</version>
+        <version>2.3.18-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/support-jacoco/pom.xml
+++ b/support-jacoco/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>ddf.support</groupId>
         <artifactId>support-pom</artifactId>
-        <version>2.3.17</version>
+        <version>2.3.18-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/support-jacoco/pom.xml
+++ b/support-jacoco/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>ddf.support</groupId>
         <artifactId>support-pom</artifactId>
-        <version>2.3.17-SNAPSHOT</version>
+        <version>2.3.17</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/support-karaf/commands/feature-tree/pom.xml
+++ b/support-karaf/commands/feature-tree/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>ddf.support</groupId>
         <artifactId>support-karaf-commands</artifactId>
-        <version>2.3.17-SNAPSHOT</version>
+        <version>2.3.17</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/support-karaf/commands/feature-tree/pom.xml
+++ b/support-karaf/commands/feature-tree/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>ddf.support</groupId>
         <artifactId>support-karaf-commands</artifactId>
-        <version>2.3.17</version>
+        <version>2.3.18-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/support-karaf/commands/pom.xml
+++ b/support-karaf/commands/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>ddf.support</groupId>
         <artifactId>support-karaf</artifactId>
-        <version>2.3.17-SNAPSHOT</version>
+        <version>2.3.17</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/support-karaf/commands/pom.xml
+++ b/support-karaf/commands/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>ddf.support</groupId>
         <artifactId>support-karaf</artifactId>
-        <version>2.3.17</version>
+        <version>2.3.18-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/support-karaf/pom.xml
+++ b/support-karaf/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>ddf.support</groupId>
         <artifactId>support-pom</artifactId>
-        <version>2.3.17-SNAPSHOT</version>
+        <version>2.3.17</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/support-karaf/pom.xml
+++ b/support-karaf/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>ddf.support</groupId>
         <artifactId>support-pom</artifactId>
-        <version>2.3.17</version>
+        <version>2.3.18-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/support-maven/artifact-size-enforcer/pom.xml
+++ b/support-maven/artifact-size-enforcer/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>ddf.support</groupId>
         <artifactId>support-maven</artifactId>
-        <version>2.3.17</version>
+        <version>2.3.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>artifact-size-enforcer</artifactId>

--- a/support-maven/artifact-size-enforcer/pom.xml
+++ b/support-maven/artifact-size-enforcer/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>ddf.support</groupId>
         <artifactId>support-maven</artifactId>
-        <version>2.3.17-SNAPSHOT</version>
+        <version>2.3.17</version>
     </parent>
 
     <artifactId>artifact-size-enforcer</artifactId>

--- a/support-maven/bundle-auto-version/pom.xml
+++ b/support-maven/bundle-auto-version/pom.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>ddf.support</groupId>
+        <artifactId>support-maven</artifactId>
+        <version>2.3.18-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <packaging>maven-plugin</packaging>
+
+    <artifactId>bundle-auto-version</artifactId>
+
+    <name>Bundle Import Auto Versioning Plugin</name>
+    <description>Utility for enforcing OSGi bundle import versions automatically</description>
+
+    <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.core.version>3.6.0</maven.core.version>
+        <maven.plugin.api.version>3.6.0</maven.plugin.api.version>
+        <maven.plugin.annotations.version>3.6.0</maven.plugin.annotations.version>
+        <maven.plugin.plugin.version>3.5</maven.plugin.plugin.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-plugin-api</artifactId>
+            <version>${maven.plugin.api.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.plugin-tools</groupId>
+            <artifactId>maven-plugin-annotations</artifactId>
+            <version>${maven.plugin.annotations.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-core</artifactId>
+            <version>${maven.core.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-plugin-plugin</artifactId>
+                <version>${maven.plugin.plugin.version}</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${maven.surefire.plugin.version}</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.apache.maven.surefire</groupId>
+                        <artifactId>surefire-junit47</artifactId>
+                        <version>${maven.surefire.plugin.version}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/support-maven/bundle-auto-version/src/main/java/org/codice/bundle/auto/version/BundleAutoVersionPlugin.java
+++ b/support-maven/bundle-auto-version/src/main/java/org/codice/bundle/auto/version/BundleAutoVersionPlugin.java
@@ -1,0 +1,171 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General private License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General private License for more details. A copy of the GNU Lesser General private
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.bundle.auto.version;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.jar.Manifest;
+import java.util.stream.Collectors;
+import org.apache.maven.model.Model;
+import org.apache.maven.model.Plugin;
+import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
+import org.apache.maven.model.io.xpp3.MavenXpp3Writer;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.util.xml.Xpp3Dom;
+import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
+
+@Mojo(
+    name = "bundle-auto-version",
+    defaultPhase = LifecyclePhase.PREPARE_PACKAGE,
+    threadSafe = true)
+public class BundleAutoVersionPlugin extends AbstractMojo {
+
+  private static final String COPYRIGHT_NOTICE =
+      "<!--\n"
+          + "/**\n"
+          + " * Copyright (c) Codice Foundation\n"
+          + " *\n"
+          + " * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either\n"
+          + " * version 3 of the License, or any later version.\n"
+          + " *\n"
+          + " * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.\n"
+          + " * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at\n"
+          + " * <http://www.gnu.org/licenses/lgpl.html>.\n"
+          + " *\n"
+          + " **/\n"
+          + " -->";
+
+  private static final String IMPORT_PACKAGE_PROP = "Import-Package";
+  private static final String MAVEN_BUNDLE_PLUGIN_ARTIFACT_ID = "maven-bundle-plugin";
+  private static final String MAVEN_CONFIG_INSTRUCTIONS = "instructions";
+
+  @Parameter(defaultValue = "${project}", required = true, readonly = true)
+  private MavenProject mavenProject;
+
+  @Override
+  public void execute() {
+    Path manifestFilePath =
+        Paths.get(mavenProject.getBuild().getOutputDirectory() + "/META-INF/MANIFEST.MF");
+
+    if (!manifestFilePath.toFile().exists()) {
+      getLog().warn("No 'MANIFEST.MF' was found in build output, skipping");
+      return;
+    }
+
+    Manifest manifest = null;
+
+    try (FileInputStream manifestInputStream = new FileInputStream(manifestFilePath.toString())) {
+      manifest = new Manifest(manifestInputStream);
+    } catch (IOException e) {
+      getLog().error("Error reading 'MANIFEST.MF' for the project", e);
+    }
+
+    if (manifest == null) throw new RuntimeException("Unable to locate generated 'MANIFEST.MF'");
+
+    String packageImports =
+        Arrays.stream(manifest.getMainAttributes().getValue(IMPORT_PACKAGE_PROP).split("\","))
+            .collect(Collectors.joining("\",\n"));
+
+    Model model =
+        Optional.ofNullable(readProjectModel(mavenProject))
+            .orElseThrow(() -> new RuntimeException("Unable to read project model from pom.xml"));
+
+    try (FileReader pomFileReader = new FileReader(mavenProject.getFile())) {
+      model = new MavenXpp3Reader().read(pomFileReader);
+    } catch (IOException | XmlPullParserException e) {
+      getLog().error("Error parsing model for Maven project", e);
+    }
+
+    Plugin mavenBundlePlugin = getMavenBundlePlugin(model.getBuild().getPlugins());
+
+    if (mavenBundlePlugin == null)
+      throw new RuntimeException("Unable to find " + mavenBundlePlugin);
+
+    Xpp3Dom configInstructions = getPluginConfiguration(mavenBundlePlugin);
+
+    if (configInstructions == null)
+      throw new RuntimeException("Unable to locate configuration for " + mavenBundlePlugin);
+
+    configInstructions.getChild(IMPORT_PACKAGE_PROP).setValue(packageImports);
+
+    saveProjectModel(mavenProject, model);
+  }
+
+  private void saveProjectModel(MavenProject project, Model model) {
+    try (FileWriter pomFileWriter = new FileWriter(new File(getProjectPomPath(project).toUri()))) {
+      new MavenXpp3Writer().write(pomFileWriter, model);
+      addCopyrightNotice(project);
+    } catch (IOException e) {
+      getLog().error("Error saving project model to pom file", e);
+    }
+  }
+
+  private void addCopyrightNotice(MavenProject project) throws IOException {
+    List<String> pomFileLines =
+        Files.lines(getProjectPomPath(project)).collect(Collectors.toList());
+
+    pomFileLines.set(0, appendCopyrightNotice(pomFileLines.get(0)));
+
+    Files.write(getProjectPomPath(project), pomFileLines, Charset.forName("UTF-8"));
+  }
+
+  private String appendCopyrightNotice(String line) {
+    return line + "\n" + COPYRIGHT_NOTICE;
+  }
+
+  private Model readProjectModel(MavenProject project) {
+    try (FileReader pomFileReader = new FileReader(project.getFile())) {
+      return new MavenXpp3Reader().read(pomFileReader);
+    } catch (IOException | XmlPullParserException e) {
+      getLog().error("Error reading project model from pom file", e);
+    }
+
+    return null;
+  }
+
+  private Path getProjectPomPath(MavenProject project) {
+    return Paths.get(project.getBasedir() + "/pom.xml");
+  }
+
+  private Plugin getMavenBundlePlugin(List<Plugin> buildPlugins) {
+    return buildPlugins.stream()
+        .filter(plugin -> MAVEN_BUNDLE_PLUGIN_ARTIFACT_ID.equals(plugin.getArtifactId()))
+        .findFirst()
+        .orElse(null);
+  }
+
+  private Xpp3Dom getPluginConfiguration(Plugin plugin) {
+    Xpp3Dom configuration =
+        Optional.ofNullable(plugin.getConfiguration()).map(Xpp3Dom.class::cast).orElse(null);
+
+    return Arrays.stream(configuration.getChildren())
+        .filter(entry -> MAVEN_CONFIG_INSTRUCTIONS.equals(entry.getName()))
+        .findFirst()
+        .orElse(null);
+  }
+}

--- a/support-maven/bundle-auto-version/src/main/java/org/codice/bundle/auto/version/MatchIterator.java
+++ b/support-maven/bundle-auto-version/src/main/java/org/codice/bundle/auto/version/MatchIterator.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General private License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General private License for more details. A copy of the GNU Lesser General private
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.bundle.auto.version;
+
+import java.util.Spliterators;
+import java.util.function.Consumer;
+import java.util.regex.Matcher;
+
+class MatchIterator extends Spliterators.AbstractSpliterator<String> {
+  private final Matcher matcher;
+
+  MatchIterator(Matcher m) {
+    super(m.regionEnd() - m.regionStart(), ORDERED | NONNULL);
+    matcher = m;
+  }
+
+  @Override
+  public boolean tryAdvance(Consumer<? super String> action) {
+    if (!matcher.find()) return false;
+    action.accept(matcher.group());
+    return true;
+  }
+}

--- a/support-maven/bundle-auto-version/src/main/java/org/codice/bundle/auto/version/SubModel.java
+++ b/support-maven/bundle-auto-version/src/main/java/org/codice/bundle/auto/version/SubModel.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General private License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General private License for more details. A copy of the GNU Lesser General private
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.bundle.auto.version;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import org.apache.maven.model.Model;
+import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
+import org.apache.maven.plugin.logging.Log;
+import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
+
+public class SubModel {
+
+  private final String name;
+  private final Path path;
+  private final Log log;
+
+  SubModel(String parentPath, String submoduleName, Log log) {
+    this.path = Paths.get(parentPath, submoduleName);
+    this.name = submoduleName;
+    this.log = log;
+  }
+
+  Model getModel() {
+    try {
+      readProjectModel();
+    } catch (IOException | XmlPullParserException e) {
+      log.error("Unable to read model for " + name, e);
+    }
+
+    return null;
+  }
+
+  private Model readProjectModel() throws XmlPullParserException, IOException {
+    FileReader pomFileReader = new FileReader(new File(path.toFile(), "pom.xml"));
+    return new MavenXpp3Reader().read(pomFileReader);
+  }
+}

--- a/support-maven/bundle-validation-plugin/pom.xml
+++ b/support-maven/bundle-validation-plugin/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>ddf.support</groupId>
         <artifactId>support-maven</artifactId>
-        <version>2.3.17-SNAPSHOT</version>
+        <version>2.3.17</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>maven-plugin</packaging>

--- a/support-maven/bundle-validation-plugin/pom.xml
+++ b/support-maven/bundle-validation-plugin/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>ddf.support</groupId>
         <artifactId>support-maven</artifactId>
-        <version>2.3.17</version>
+        <version>2.3.18-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>maven-plugin</packaging>

--- a/support-maven/bundle-validation-plugin/pom.xml
+++ b/support-maven/bundle-validation-plugin/pom.xml
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>ddf.support</groupId>
+        <artifactId>support-maven</artifactId>
+        <version>2.3.17-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <packaging>maven-plugin</packaging>
+
+    <artifactId>bundle-validation-plugin</artifactId>
+
+    <name>Bundle Import Version Validation Plugin</name>
+    <description>Utility for enforcing OSGi bundle import versions</description>
+
+    <properties>
+        <commons-lang3.version>3.4</commons-lang3.version>
+        <maven.plugin.api.version>3.6.0</maven.plugin.api.version>
+        <maven.plugin.annotations.version>3.6.0</maven.plugin.annotations.version>
+        <maven.core.version>3.6.0</maven.core.version>
+        <junit.version>4.12</junit.version>
+        <mockito-all.version>1.10.19</mockito-all.version>
+        <maven.plugin.plugin.version>3.5</maven.plugin.plugin.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>${commons-lang3.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-plugin-api</artifactId>
+            <version>${maven.plugin.api.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.plugin-tools</groupId>
+            <artifactId>maven-plugin-annotations</artifactId>
+            <version>${maven.plugin.annotations.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-core</artifactId>
+            <version>${maven.core.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+            <version>${mockito-all.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-plugin-plugin</artifactId>
+                <version>${maven.plugin.plugin.version}</version>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>${maven.jacoco.plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>default-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <haltOnFailure>true</haltOnFailure>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit implementation="org.codice.jacoco.LenientLimit">
+                                            <counter>INSTRUCTION</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.73</minimum>
+                                        </limit>
+                                        <limit implementation="org.codice.jacoco.LenientLimit">
+                                            <counter>BRANCH</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.75</minimum>
+                                        </limit>
+                                        <limit implementation="org.codice.jacoco.LenientLimit">
+                                            <counter>COMPLEXITY</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.75</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/support-maven/bundle-validation-plugin/src/main/java/org/codice/plugin/bundle/BundleImportValidationPlugin.java
+++ b/support-maven/bundle-validation-plugin/src/main/java/org/codice/plugin/bundle/BundleImportValidationPlugin.java
@@ -1,0 +1,276 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.plugin.bundle;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Predicate;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.maven.model.Plugin;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.util.xml.Xpp3Dom;
+
+@Mojo(
+    name = "validate-import-versions",
+    defaultPhase = LifecyclePhase.VALIDATE,
+    threadSafe = true)
+public class BundleImportValidationPlugin extends AbstractMojo {
+
+  private static final String OUTPUT_FILENAME = "bundleImportValidationResults.txt";
+
+  private static final String FAILURE_SUMMARY_FILENAME = "importVersionValidationFailures.txt";
+
+  private static final String CONFIG_OPTION_TO_VALIDATE = "Import-Package";
+
+  private static final Predicate<String> IS_VALID_IMPORT =
+      importString -> importString.contains("version=");
+
+  private static final Predicate<String> IS_NOT_IGNORED_IMPORT = value -> !value.startsWith("!");
+
+  private static final String NO_PACKAGE_IMPORTS_FOUND =
+      "No package imports specified; this defaults to a * import";
+
+  private static final Pattern IMPORT_VALUE_PATTERN =
+      Pattern.compile("(?:[^,\\\"]+|(?:\\\"[^\\\"]*\\\"))+|[^,]+");
+
+  @Parameter(defaultValue = "${project}", readonly = true, required = true)
+  private MavenProject project;
+
+  @Parameter(defaultValue = "${}")
+  private List<String> excludedModules;
+
+  @Parameter(defaultValue = "${}")
+  private List<String> warnOnlyModules;
+
+  @Parameter(defaultValue = "true")
+  private boolean writeModuleResultsToTarget;
+
+  @Parameter private String failureSummaryDirectory;
+
+  @Override
+  public void execute() throws MojoFailureException {
+    if (excludedModules.contains(project.getArtifactId())) {
+      getLog().info("Skipping import validation for excluded module " + project.getName());
+      return;
+    }
+    Plugin mavenBundlePlugin = getMavenBundlePlugin();
+    if (mavenBundlePlugin == null) {
+      getLog()
+          .info(
+              "Skipping import validation; bundle plugin not configured for " + project.getName());
+      return;
+    }
+
+    List<ValidationResult> validationResults = validateConfiguredImports(mavenBundlePlugin);
+    if (writeModuleResultsToTarget) {
+      writeTargetOutput(validationResults);
+    }
+
+    List<ValidationResult> failures =
+        validationResults.stream().filter(result -> !result.isValid).collect(Collectors.toList());
+
+    if (failures.isEmpty() && !validationResults.isEmpty()) {
+      getLog().info("All import versions appear valid in " + project.getName());
+      return;
+    }
+
+    getLog().warn("Bundle version validation failed for " + project.getName());
+    if (validationResults.isEmpty()) {
+      getLog().warn(NO_PACKAGE_IMPORTS_FOUND);
+    }
+
+    if (StringUtils.isNotBlank(failureSummaryDirectory)) {
+      writeFailureSummary(failures);
+    }
+
+    if (!warnOnlyModules.contains(project.getArtifactId()) && !warnOnlyModules.contains("*")) {
+      throw new MojoFailureException("Invalid bundle version configured in " + project.getName());
+    }
+  }
+
+  List<ValidationResult> validateConfiguredImports(Plugin mavenBundlePlugin) {
+    getLog().info("Validating import versions in " + project.getName());
+
+    Xpp3Dom bundlePluginConfig = (Xpp3Dom) mavenBundlePlugin.getConfiguration();
+    return Arrays.stream(bundlePluginConfig.getChildren())
+        .map(this::validateConfig)
+        .flatMap(Collection::stream)
+        .collect(Collectors.toList());
+  }
+
+  void setProject(MavenProject project) {
+    this.project = project;
+  }
+
+  void setExcludedModules(List<String> excludedModules) {
+    this.excludedModules = excludedModules;
+  }
+
+  void setWarnOnlyModules(List<String> warnOnlyModules) {
+    this.warnOnlyModules = warnOnlyModules;
+  }
+
+  private Plugin getMavenBundlePlugin() {
+    return project.getBuildPlugins().stream()
+        .filter(plugin -> "maven-bundle-plugin".equals(plugin.getArtifactId()))
+        .findFirst()
+        .orElse(null);
+  }
+
+  private List<ValidationResult> validateConfig(Xpp3Dom current) {
+    if (current.getChildCount() > 0) {
+      return Arrays.stream(current.getChildren())
+          .filter(child -> CONFIG_OPTION_TO_VALIDATE.equals(child.getName()))
+          .map(this::validateConfig)
+          .flatMap(Collection::stream)
+          .collect(Collectors.toList());
+    }
+
+    if (!CONFIG_OPTION_TO_VALIDATE.equals(current.getName())) {
+      return Collections.emptyList();
+    }
+    List<ValidationResult> results = validateImports(current.getValue());
+    if (results.isEmpty()) {
+      return Collections.singletonList(new ValidationResult("No Packages Imported", true));
+    }
+    return results;
+  }
+
+  private List<ValidationResult> validateImports(String importString) {
+    if (StringUtils.isBlank(importString)) {
+      return Collections.emptyList();
+    }
+    return extractImports(importString).stream()
+        .map(String::trim)
+        .filter(IS_NOT_IGNORED_IMPORT)
+        .map(this::validate)
+        .collect(Collectors.toList());
+  }
+
+  private List<String> extractImports(String line) {
+    List<String> imports = new ArrayList<>();
+    Matcher m = IMPORT_VALUE_PATTERN.matcher(line);
+    while (m.find()) {
+      imports.add(m.group());
+    }
+    return imports;
+  }
+
+  private ValidationResult validate(String line) {
+    getLog().info("Testing import: " + line);
+
+    ValidationResult validationResult = new ValidationResult(line, IS_VALID_IMPORT.test(line));
+    if (validationResult.isValid()) {
+      return validationResult;
+    }
+
+    if (warnOnlyModules.contains(project.getArtifactId()) || warnOnlyModules.contains("*")) {
+      getLog().warn("Import with missing version found: " + line);
+    } else {
+      getLog().error("Import with missing version found: " + line);
+    }
+    return validationResult;
+  }
+
+  private void writeTargetOutput(List<ValidationResult> validationResults) {
+    String targetDir = project.getBuild().getDirectory();
+    StringBuilder validationResultSummary = buildValidationResultSummary(validationResults);
+    writeToFile(targetDir, OUTPUT_FILENAME, validationResultSummary);
+  }
+
+  StringBuilder buildValidationResultSummary(List<ValidationResult> validationResults) {
+    StringBuilder validationResultSummary = new StringBuilder();
+    validationResultSummary
+        .append("Import validation results for ")
+        .append(project.getName())
+        .append("\n\n");
+
+    if (validationResults.isEmpty()) {
+      validationResultSummary.append("Invalid  -  ").append(NO_PACKAGE_IMPORTS_FOUND).append("\n");
+      return validationResultSummary;
+    }
+
+    for (ValidationResult result : validationResults) {
+      validationResultSummary.append(result).append("\n");
+    }
+    return validationResultSummary;
+  }
+
+  private void writeFailureSummary(List<ValidationResult> failures) {
+    StringBuilder failureSummary = new StringBuilder();
+    failureSummary.append("Invalid imports found in ").append(project.getName()).append("\n");
+
+    if (failures.isEmpty()) {
+      failureSummary.append(NO_PACKAGE_IMPORTS_FOUND).append("\n\n");
+    } else {
+      for (ValidationResult failure : failures) {
+        failureSummary.append(failure.importString).append("\n");
+      }
+      failureSummary.append(failures.size()).append(" import(s) with no version.\n\n");
+    }
+
+    synchronized (BundleImportValidationPlugin.class) {
+      writeToFile(failureSummaryDirectory, FAILURE_SUMMARY_FILENAME, failureSummary);
+    }
+  }
+
+  private void writeToFile(String path, String fileName, CharSequence output) {
+    boolean created = new File(path).mkdirs();
+    if (created) {
+      getLog().info("Created directory for: " + path);
+    }
+
+    File file = new File(path, fileName);
+    getLog().info("Writing output to: " + file.getAbsolutePath());
+
+    try (FileWriter fileWriter = new FileWriter(file, true)) {
+      fileWriter.append(output);
+    } catch (IOException e) {
+      getLog().warn("Failed to write output to: " + file.getAbsolutePath(), e);
+    }
+  }
+
+  static class ValidationResult {
+    private final String importString;
+    private final boolean isValid;
+
+    ValidationResult(String value, boolean isValid) {
+      this.importString = value;
+      this.isValid = isValid;
+    }
+
+    public String toString() {
+      String valid = isValid ? "Valid" : "Invalid";
+      return String.format("%-9s-  %s", valid, importString);
+    }
+
+    public boolean isValid() {
+      return this.isValid;
+    }
+  }
+}

--- a/support-maven/bundle-validation-plugin/src/test/java/org/codice/plugin/bundle/BundleImportValidationPluginTest.java
+++ b/support-maven/bundle-validation-plugin/src/test/java/org/codice/plugin/bundle/BundleImportValidationPluginTest.java
@@ -1,0 +1,173 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.plugin.bundle;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.InputStream;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.apache.maven.model.Plugin;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.util.xml.Xpp3DomBuilder;
+import org.codice.plugin.bundle.BundleImportValidationPlugin.ValidationResult;
+import org.junit.Before;
+import org.junit.Test;
+
+public class BundleImportValidationPluginTest {
+
+  private static final String MAVEN_BUNDLE_PLUGIN = "maven-bundle-plugin";
+
+  private static final String ARTIFACT_ID = "artifact";
+
+  private static final String VALID_CONFIG = "validConfig.txt";
+
+  private static final String INVALID_CONFIG = "invalidConfig.txt";
+
+  private static final String NO_IMPORT_CONFIG = "noImportConfig.txt";
+
+  private MavenProject project;
+
+  private BundleImportValidationPlugin validationPlugin;
+
+  @Before
+  public void setUp() {
+    project = mock(MavenProject.class);
+    validationPlugin = new BundleImportValidationPlugin();
+    validationPlugin.setProject(project);
+    validationPlugin.setExcludedModules(Collections.emptyList());
+    validationPlugin.setWarnOnlyModules(Collections.emptyList());
+    when(project.getName()).thenReturn("project");
+    when(project.getArtifactId()).thenReturn(ARTIFACT_ID);
+  }
+
+  @Test
+  public void testNoBuildPluginSucceeds() throws Exception {
+    when(project.getBuildPlugins()).thenReturn(Collections.emptyList());
+    validationPlugin.execute();
+  }
+
+  @Test(expected = MojoFailureException.class)
+  public void testInvalidConfigFails() throws Exception {
+    InputStream configStream = getClass().getClassLoader().getResourceAsStream(INVALID_CONFIG);
+
+    Plugin buildPlugin = mock(Plugin.class);
+    when(buildPlugin.getArtifactId()).thenReturn(MAVEN_BUNDLE_PLUGIN);
+    when(buildPlugin.getConfiguration())
+        .thenReturn(Xpp3DomBuilder.build(configStream, UTF_8.name()));
+    when(project.getBuildPlugins()).thenReturn(Collections.singletonList(buildPlugin));
+    validationPlugin.execute();
+  }
+
+  @Test(expected = MojoFailureException.class)
+  public void testConfigWithoutImportFails() throws Exception {
+    InputStream configStream = getClass().getClassLoader().getResourceAsStream(NO_IMPORT_CONFIG);
+
+    Plugin buildPlugin = mock(Plugin.class);
+    when(buildPlugin.getArtifactId()).thenReturn(MAVEN_BUNDLE_PLUGIN);
+    when(buildPlugin.getConfiguration())
+        .thenReturn(Xpp3DomBuilder.build(configStream, UTF_8.name()));
+    when(project.getBuildPlugins()).thenReturn(Collections.singletonList(buildPlugin));
+    validationPlugin.execute();
+  }
+
+  @Test
+  public void testValidConfigSucceeds() throws Exception {
+    InputStream configStream = getClass().getClassLoader().getResourceAsStream(VALID_CONFIG);
+
+    Plugin buildPlugin = mock(Plugin.class);
+    when(buildPlugin.getArtifactId()).thenReturn(MAVEN_BUNDLE_PLUGIN);
+    when(buildPlugin.getConfiguration())
+        .thenReturn(Xpp3DomBuilder.build(configStream, UTF_8.name()));
+    when(project.getBuildPlugins()).thenReturn(Collections.singletonList(buildPlugin));
+    validationPlugin.execute();
+
+    List<ValidationResult> results = validationPlugin.validateConfiguredImports(buildPlugin);
+    assertThat(results.size(), is(4));
+  }
+
+  @Test
+  public void testInvalidConfigSucceedsIfWarnOnly() throws Exception {
+    validationPlugin.setWarnOnlyModules(Collections.singletonList(ARTIFACT_ID));
+    InputStream configStream = getClass().getClassLoader().getResourceAsStream(INVALID_CONFIG);
+
+    Plugin buildPlugin = mock(Plugin.class);
+    when(buildPlugin.getArtifactId()).thenReturn(MAVEN_BUNDLE_PLUGIN);
+    when(buildPlugin.getConfiguration())
+        .thenReturn(Xpp3DomBuilder.build(configStream, UTF_8.name()));
+    when(project.getBuildPlugins()).thenReturn(Collections.singletonList(buildPlugin));
+    validationPlugin.execute();
+
+    List<ValidationResult> results = validationPlugin.validateConfiguredImports(buildPlugin);
+    List<ValidationResult> failures =
+        results.stream().filter(result -> !result.isValid()).collect(Collectors.toList());
+    assertThat(results.size(), is(3));
+    assertThat(failures.size(), is(2));
+  }
+
+  @Test
+  public void testInvalidConfigSucceedsIfExcluded() throws Exception {
+    validationPlugin.setExcludedModules(Collections.singletonList(ARTIFACT_ID));
+    InputStream configStream = getClass().getClassLoader().getResourceAsStream(INVALID_CONFIG);
+
+    Plugin buildPlugin = mock(Plugin.class);
+    when(buildPlugin.getArtifactId()).thenReturn(MAVEN_BUNDLE_PLUGIN);
+    when(buildPlugin.getConfiguration())
+        .thenReturn(Xpp3DomBuilder.build(configStream, UTF_8.name()));
+    when(project.getBuildPlugins()).thenReturn(Collections.singletonList(buildPlugin));
+    validationPlugin.execute();
+
+    verify(project, times(0)).getBuildPlugins();
+  }
+
+  @Test
+  public void testBuildValidationSummary() throws Exception {
+    InputStream configStream = getClass().getClassLoader().getResourceAsStream(INVALID_CONFIG);
+
+    Plugin buildPlugin = mock(Plugin.class);
+    when(buildPlugin.getArtifactId()).thenReturn(MAVEN_BUNDLE_PLUGIN);
+    when(buildPlugin.getConfiguration())
+        .thenReturn(Xpp3DomBuilder.build(configStream, UTF_8.name()));
+    when(project.getBuildPlugins()).thenReturn(Collections.singletonList(buildPlugin));
+
+    List<ValidationResult> results = validationPlugin.validateConfiguredImports(buildPlugin);
+    StringBuilder summary = validationPlugin.buildValidationResultSummary(results);
+    assertThat(summary.toString().contains("Valid"), is(true));
+    assertThat(summary.toString().contains("Invalid"), is(true));
+  }
+
+  @Test
+  public void testBuildValidationSummaryNoImports() throws Exception {
+    InputStream configStream = getClass().getClassLoader().getResourceAsStream(NO_IMPORT_CONFIG);
+
+    Plugin buildPlugin = mock(Plugin.class);
+    when(buildPlugin.getArtifactId()).thenReturn(MAVEN_BUNDLE_PLUGIN);
+    when(buildPlugin.getConfiguration())
+        .thenReturn(Xpp3DomBuilder.build(configStream, UTF_8.name()));
+    when(project.getBuildPlugins()).thenReturn(Collections.singletonList(buildPlugin));
+
+    List<ValidationResult> results = validationPlugin.validateConfiguredImports(buildPlugin);
+    StringBuilder summary = validationPlugin.buildValidationResultSummary(results);
+    assertThat(summary.toString().contains("No package imports specified"), is(true));
+    assertThat(summary.toString().contains("Valid"), is(false));
+  }
+}

--- a/support-maven/bundle-validation-plugin/src/test/resources/invalidConfig.txt
+++ b/support-maven/bundle-validation-plugin/src/test/resources/invalidConfig.txt
@@ -1,0 +1,11 @@
+<configuration>
+    <instructions>
+        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+        <Import-Package>
+            package1,
+            package2;version="[1.0,3)",
+            !package3,
+            *
+        </Import-Package>
+    </instructions>
+</configuration>

--- a/support-maven/bundle-validation-plugin/src/test/resources/noImportConfig.txt
+++ b/support-maven/bundle-validation-plugin/src/test/resources/noImportConfig.txt
@@ -1,0 +1,6 @@
+<configuration>
+    <instructions>
+        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+        <Export-Package>somePackage</Export-Package>
+    </instructions>
+</configuration>

--- a/support-maven/bundle-validation-plugin/src/test/resources/validConfig.txt
+++ b/support-maven/bundle-validation-plugin/src/test/resources/validConfig.txt
@@ -1,0 +1,11 @@
+<configuration>
+    <instructions>
+        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+        <Import-Package>
+            package1;version="[5.5,6.2)", package2;version="[1.0,3)",
+            org.eclipse.jdt.ui;bundle-symbolic-name="jdt-ui";version="[1.3,2.0)";resolution:=dynamic,
+            com.acme.foo;version=1.0.0,
+            !package3
+        </Import-Package>
+    </instructions>
+</configuration>

--- a/support-maven/pom.xml
+++ b/support-maven/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>ddf.support</groupId>
         <artifactId>support-pom</artifactId>
-        <version>2.3.17-SNAPSHOT</version>
+        <version>2.3.17</version>
     </parent>
 
     <artifactId>support-maven</artifactId>

--- a/support-maven/pom.xml
+++ b/support-maven/pom.xml
@@ -28,6 +28,7 @@
         <module>version-validation-plugin</module>
         <module>artifact-size-enforcer</module>
         <module>bundle-validation-plugin</module>
+        <module>bundle-auto-version</module>
     </modules>
     
 </project>

--- a/support-maven/pom.xml
+++ b/support-maven/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>ddf.support</groupId>
         <artifactId>support-pom</artifactId>
-        <version>2.3.17</version>
+        <version>2.3.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>support-maven</artifactId>

--- a/support-maven/pom.xml
+++ b/support-maven/pom.xml
@@ -27,6 +27,7 @@
     <modules>
         <module>version-validation-plugin</module>
         <module>artifact-size-enforcer</module>
+        <module>bundle-validation-plugin</module>
     </modules>
     
 </project>

--- a/support-maven/version-validation-plugin/pom.xml
+++ b/support-maven/version-validation-plugin/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>ddf.support</groupId>
         <artifactId>support-maven</artifactId>
-        <version>2.3.17-SNAPSHOT</version>
+        <version>2.3.17</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>maven-plugin</packaging>

--- a/support-maven/version-validation-plugin/pom.xml
+++ b/support-maven/version-validation-plugin/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>ddf.support</groupId>
         <artifactId>support-maven</artifactId>
-        <version>2.3.17</version>
+        <version>2.3.18-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>maven-plugin</packaging>

--- a/support-owasp/pom.xml
+++ b/support-owasp/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>ddf.support</groupId>
         <artifactId>support-pom</artifactId>
-        <version>2.3.17-SNAPSHOT</version>
+        <version>2.3.17</version>
     </parent>
 
     <artifactId>support-owasp</artifactId>

--- a/support-owasp/pom.xml
+++ b/support-owasp/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>ddf.support</groupId>
         <artifactId>support-pom</artifactId>
-        <version>2.3.17</version>
+        <version>2.3.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>support-owasp</artifactId>

--- a/support-pmd/pom.xml
+++ b/support-pmd/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>ddf.support</groupId>
         <artifactId>support-pom</artifactId>
-        <version>2.3.17-SNAPSHOT</version>
+        <version>2.3.17</version>
     </parent>
 
     <artifactId>support-pmd</artifactId>

--- a/support-pmd/pom.xml
+++ b/support-pmd/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>ddf.support</groupId>
         <artifactId>support-pom</artifactId>
-        <version>2.3.17</version>
+        <version>2.3.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>support-pmd</artifactId>


### PR DESCRIPTION
This plugin runs (should run) in the `package` phase, after the `maven-bundle-plugin` has executed and generated the `MANIFEST.MF` for the bundle with the relevant `Import-Package` entries.

The plugin reads the generated `MANIFEST.MF`, picks out the `Import-Package` entries (with versions). It also reads the project's pom.xml and replaces the `Import-Package` config of the `maven-bundle-plugin` with entries from `MANIFEST.MF`. It then overwrites the existing pom.xml with the updated model.

Currently the pom.xml overwrite will happen at every execution. Next step is to only update it if the manifest entries are different than what is in the pom.

Issue: #4 

How to try this. Add the following to a pom.xml which already contains a `maven-bundle-plugin` configuration:

```
<dependencies>
    ....
    <dependency>
      <groupId>ddf.support</groupId>
      <artifactId>bundle-auto-version</artifactId>
      <version>2.3.18-SNAPSHOT</version>
    </dependency>
    ....
</dependencies>

...

  <build>
    <plugins>
      ....
      <plugin>
        <groupId>ddf.support</groupId>
        <artifactId>bundle-auto-version</artifactId>
        <version>2.3.18-SNAPSHOT</version>
        <executions>
          <execution>
            <phase>package</phase>
            <goals>
              <goal>bundle-auto-version</goal>
            </goals>
          </execution>
        </executions>
      </plugin>
      ....
    </plugins>
</build>
```